### PR TITLE
add Bar orientation option

### DIFF
--- a/data_plot.py
+++ b/data_plot.py
@@ -94,11 +94,46 @@ class DataPlot:
         for k,v in self.orientations.items():
             self.dlg.orientationCombo.addItem(v, k)
 
+        # Add data to symbol type combo
+        self.symbolType = {
+            'markers': self.tr('Points'),
+            'lines': self.tr('Lines'),
+            'markers+lines': self.tr('Points and Lines')
+        }
+        self.dlg.symbolCombo.clear()
+        for k,v in self.symbolType.items():
+            self.dlg.symbolCombo.addItem(v, k)
+
         # Add data to vertical/horizontal combo
         self.figureTypes = {
             'classic': self.tr(u'Classic'),
             'subplots': self.tr(u'Subplots with shared axis')
         }
+
+        # Add data for the showing statistics type (box plot only)
+        self.statType = {
+            True: self.tr('Mean'),
+            'sd': self.tr('Standard Deviation'),
+            False: self.tr('No Statistics')
+        }
+        self.dlg.statCombo.clear()
+        for k,v in self.statType.items():
+            self.dlg.statCombo.addItem(v, k)
+
+        # Add data for the showing outliers (box plot only)
+        self.outlierType = {
+            False: self.tr('No Outliers'),
+            'all': self.tr('Show All Outliers'),
+            'suspectedoutliers': self.tr('Only Suspected Outliers'),
+            'outliers': self.tr('Outliers')
+
+        }
+        self.dlg.outlierCombo.clear()
+        for k,v in self.outlierType.items():
+            self.dlg.outlierCombo.addItem(v, k)
+
+
+        #
         self.dlg.figureTypeCombo.clear()
         for k,v in self.figureTypes.items():
             self.dlg.figureTypeCombo.addItem(v, k)
@@ -463,10 +498,66 @@ class DataPlot:
                 )
             )
 
-            # idx = self.dlg.orientationCombo.currentIndex()
-            # ori = self.dlg.orientationCombo.itemData(idx)
-            #
-            # sprop['orientation'] = ori
+            idx = self.dlg.orientationCombo.currentIndex()
+            ori = self.dlg.orientationCombo.itemData(idx)
+
+            sprop['orientation'] = ori
+
+
+
+
+        if ptype == 'scatter':
+            color = hex_to_rgb(self.dlg.colorButton.color().name())
+            color_line = hex_to_rgb(self.dlg.colorButton2.color().name())
+            width = self.dlg.widthBox.value()
+            size = self.dlg.Size.value()
+
+            idx = self.dlg.symbolCombo.currentIndex()
+            mode = self.dlg.symbolCombo.itemData(idx)
+
+            sprop['mode'] = mode
+
+            sprop['marker'] = dict(
+                color = 'rgb' + color,
+                size = size,
+                line = dict(
+                    color = 'rgb' + str(color_line),
+                    width = width
+                )
+            )
+
+        if ptype == 'box':
+            color = hex_to_rgb(self.dlg.colorButton.color().name())
+            color_line = hex_to_rgb(self.dlg.colorButton2.color().name())
+            width = self.dlg.widthBox.value()
+
+
+            # box fill color
+            sprop['fillcolor'] = 'rgb' + color
+
+            # outlines box color and width
+            sprop['line'] = dict(
+                color = 'rgb' + color_line,
+                width = width
+            )
+
+            # optional outlier points color
+            sprop['marker'] = dict(
+                color = 'rgb' + color,
+            )
+
+
+            idx = self.dlg.statCombo.currentIndex()
+            stat = self.dlg.statCombo.itemData(idx)
+
+            sprop['boxmean'] = stat
+
+            idx = self.dlg.outlierCombo.currentIndex()
+            out = self.dlg.outlierCombo.itemData(idx)
+
+            sprop['boxpoints'] = out
+
+
 
         return sprop
 

--- a/data_plot.py
+++ b/data_plot.py
@@ -87,8 +87,8 @@ class DataPlot:
 
         # Add data to vertical/horizontal combo
         self.orientations = {
-            'vertical': self.tr('Vertical'),
-            'horizontal': self.tr('Horizontal')
+            'v': self.tr('Vertical'),
+            'h': self.tr('Horizontal')
         }
         self.dlg.orientationCombo.clear()
         for k,v in self.orientations.items():
@@ -462,6 +462,11 @@ class DataPlot:
                     width = width
                 )
             )
+
+            # idx = self.dlg.orientationCombo.currentIndex()
+            # ori = self.dlg.orientationCombo.itemData(idx)
+            #
+            # sprop['orientation'] = ori
 
         return sprop
 

--- a/data_plot_trace.py
+++ b/data_plot_trace.py
@@ -167,6 +167,28 @@ class DataPlotTrace(QObject):
             trace = go.Bar(self.plot_properties)
             self.plot_trace = trace
 
+        elif pt == 'scatter':
+
+            # Add needed properties
+            self.plot_properties['x'] = self.plot_data['x']
+            self.plot_properties['y'] = self.plot_data['y']
+
+            # Add plot
+            trace = go.Scatter(self.plot_properties)
+            self.plot_trace = trace
+
+        elif pt == 'box':
+
+            # Add needed properties
+            self.plot_properties['x'] = self.plot_data['x']
+            self.plot_properties['y'] = self.plot_data['y']
+
+            # Add plot
+            trace = go.Box(self.plot_properties)
+            self.plot_trace = trace
+
+
+
         else:
             return
 
@@ -176,4 +198,3 @@ class DataPlotTrace(QObject):
         '''
         layout = go.Layout( self.plot_layout )
         return layout
-


### PR DESCRIPTION
Just changed the plotly required name for bar orientation.

BTW: I copied the lines of the ``getTypeLayout`` function (just below the added code).. else the plot was not being rendered.

Issue: if horizontal, also the groups are re-computed.. that means the user has to invert the X and Y values. Should with add an if loop? I did not expect that behavior as user 